### PR TITLE
updated accumulo-core version to 1.6.0-cdh4.6.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>org.apache.accumulo</groupId>
                 <artifactId>accumulo-core</artifactId>
-                <version>1.6.0-cdh4.6.0-SNAPSHOT</version>
+                <version>1.6.0-cdh4.6.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
I updated the version of accumulo-core to 1.6.0-cdh4.6.0, which was released in July. Once this change is merged in we won't have any snapshot dependencies in the parent pom.
