### PR TITLE
Distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,24 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.6</slf4j.version>
+        <!--<release.repository>https://oss.sonatype.org/service/local/staging/deploy/maven2/</release.repository>-->
+        <!--<snapshot.repository>https://oss.sonatype.org/content/repositories/snapshots/</snapshot.repository>-->
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>central</id>
+            <name>Central Repoistory For Maven Artifacts</name>
+            <url>${release.repository}</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <name>snapshots</name>
+            <url>${snapshot.repository}</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -26,6 +42,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.6</slf4j.version>
-        <!--<release.repository>https://oss.sonatype.org/service/local/staging/deploy/maven2/</release.repository>-->
-        <!--<snapshot.repository>https://oss.sonatype.org/content/repositories/snapshots/</snapshot.repository>-->
+
+        <!-- Note: The following 2 properties are required to be set (in a user profile or
+             on the command line) before running the deploy goal -->
+        <!--<release.repository>[url of release repository]</release.repository>-->
+        <!--<snapshot.repository>[url of snapshot repository]</snapshot.repository>-->
     </properties>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <distributionManagement>
         <repository>
-            <id>central</id>
+            <id>repo</id>
             <name>Central Repoistory For Maven Artifacts</name>
             <url>${release.repository}</url>
         </repository>


### PR DESCRIPTION
We need to be able to deploy the ezbake parent pom, but don't currently have a target repository. This adds the distribution management section and lays out the properties so that they can be updated in this pom or set externally.
